### PR TITLE
outputディレクトリの末尾に処理の内容を記載

### DIFF
--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -70,7 +70,7 @@ def setup_logging(mode: str) -> LoggingContext:
     logger.addHandler(stream_handler)
 
     logger.info(
-        "Loggingを初期化しました。 level=%s run_dir=%s",
+        "Loggingを初期化しました：level=%s run_dir=%s",
         logging.getLevelName(logger.level),
         run_dir,
     )

--- a/src/main.py
+++ b/src/main.py
@@ -41,7 +41,7 @@ def main(csv_input: str):
 
     if csv_input:
         # 指定された入力ファイルで CSV を作成して終了
-        logger.info("%s の速度・滞在情報付きCSVを作成します。", csv_input)
+        logger.info("速度・滞在情報付きCSVを作成します：%s", csv_input)
         process_speed_data(
             input_csv=csv_input,
             output_csv="speed.csv",


### PR DESCRIPTION
既存のログディレクトリの名前が`output/20251202_093348`のようになっていて,どの実行モード(CSVなのかヒートマップなのか)でプログラムを実行しているかがわかりづらい.
なのでログディレクトリの名前の末尾に`output/20251202_093348_csv`,`output/20251202_093348_heatmap`のように実行モードの文字列を追加した
<img width="202" height="78" alt="スクリーンショット 2025-12-02 19 10 58" src="https://github.com/user-attachments/assets/cf2da146-7d85-4d98-9815-676fa2c91f67" />
