### PR TITLE
stay判定をそもそも0.5秒まではFalseとして処理する

### DIFF
--- a/src/process_thresholded_trajectory.py
+++ b/src/process_thresholded_trajectory.py
@@ -93,7 +93,11 @@ def process_thresholded_trajectory(
     df = pd.merge(df_traj, df_speed[["time", "speed"]], on="time", how="left")
 
     # Mark stays
-    df["stay"] = df["speed"] <= threshold
+    # 0.5秒までのtimeは滞在とみなさない
+    if (df["time"] <= 0.5).any():
+        df["stay"] = False
+    else:
+        df["stay"] = df["speed"] <= threshold
 
     # 出力CSVの書き出し（失敗時はログ出力して再送出）
     try:


### PR DESCRIPTION
滞在判定は元々速度データを用いており,速度が閾値よりも小さい場合は滞在をTrueにしていた。
そのため、データを取得し始めたタイミング(つまり、歩き始め)でTrueと判定されてしまっている。歩き始めのタイミングがTrueに判定されてしまうことでヒートマップを生成した時にその地点が赤くなってしまう。赤くなってしまうと実際に施策をしている箇所がかすんでみえる。
それを改善するため、時間が0.5秒より小さい場合はすべてFalseとして判定するように変更。