### PR TITLE
初期位置を除外

### DIFF
--- a/src/calculate_stay_count.py
+++ b/src/calculate_stay_count.py
@@ -1,4 +1,4 @@
-def calculate_stay_count(df_transformed, GRID_SIZE_PX):
+def calculate_stay_count(df_transformed, GRID_SIZE_PX, excluded_grids=None):
     """
     軌跡データから各グリッドへの滞在回数を計算する。
     同じグリッドに留まり続けている場合は1回とカウントし、
@@ -7,27 +7,42 @@ def calculate_stay_count(df_transformed, GRID_SIZE_PX):
     Args:
         df_transformed (pd.DataFrame): 変換後の軌跡データ。'transformed_x', 'transformed_y' カラムを持つ。
         GRID_SIZE_PX (int): グリッドの1辺のピクセルサイズ。
+        excluded_grids (iterable[tuple[int, int]] | None): 集計から除外するグリッドIDのリスト/集合。
 
     Returns:
         dict: 各グリッドIDをキー、滞在回数を値とする辞書。例: {(col, row): count}
     """
 
-    df_transformed = df_transformed[df_transformed['stay'] == True].copy()
+    df_transformed = df_transformed[df_transformed["stay"] == True].copy()
 
     if df_transformed.empty:
         return {}
 
     # 各点のグリッドIDを計算
-    df_transformed['grid_col'] = (df_transformed['x_final'] // GRID_SIZE_PX).astype(int)
-    df_transformed['grid_row'] = (df_transformed['y_final'] // GRID_SIZE_PX).astype(int)
+    df_transformed["grid_col"] = (df_transformed["x_final"] // GRID_SIZE_PX).astype(int)
+    df_transformed["grid_row"] = (df_transformed["y_final"] // GRID_SIZE_PX).astype(int)
+
+    if excluded_grids:
+        excluded_set = {grid for grid in excluded_grids if grid is not None}
+        if excluded_set:
+            # 変換原点など集計対象外のグリッドを除去
+            df_transformed["grid_id"] = list(
+                zip(df_transformed["grid_col"], df_transformed["grid_row"])
+            )
+            df_transformed = df_transformed[
+                ~df_transformed["grid_id"].isin(excluded_set)
+            ].copy()
+            df_transformed = df_transformed.drop(columns="grid_id")
+            if df_transformed.empty:
+                return {}
 
     # 前の点とグリッドIDが異なる点のみを抽出（グリッドの移動を検出）
     grid_visits = df_transformed[
-        (df_transformed['grid_col'] != df_transformed['grid_col'].shift(1)) |
-        (df_transformed['grid_row'] != df_transformed['grid_row'].shift(1))
+        (df_transformed["grid_col"] != df_transformed["grid_col"].shift(1))
+        | (df_transformed["grid_row"] != df_transformed["grid_row"].shift(1))
     ]
 
     # グリッドごとの訪問回数をカウント
-    stay_counts = grid_visits.groupby(['grid_col', 'grid_row']).size().to_dict()
+    stay_counts = grid_visits.groupby(["grid_col", "grid_row"]).size().to_dict()
 
     return stay_counts

--- a/src/calculate_stay_time.py
+++ b/src/calculate_stay_time.py
@@ -2,36 +2,54 @@ import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
 
-def calculate_stay_time(df_trajectory, grid_size, map_width, map_height):
-	# diff()で前後の行との差を計算し、最初の行はNaNになるため0で埋める
-	df_trajectory['time_diff'] = df_trajectory['time'].diff().fillna(0)
-     
-	def find_grid_id(x, y, grid_size, map_width_px, map_height_px):
-		"""
-		座標(x, y)がどのグリッドIDに属するかを計算する。
-		マップ範囲外の場合は-1を返す。
-		"""
-		# print(f"x: {x}, y: {y},grid_size{grid_size}, map_width_px: {map_width_px}, map_height_px: {map_height_px}")
-		if not (0 <= x < map_width_px and 0 <= y < map_height_px):
-			return -1  # マップの範囲外
-		
-		# 座標がどのグリッドの列・行に位置するかを計算
-		grid_col = int(x // grid_size)
-		grid_row = int(y // grid_size)
-		
-		return (grid_col, grid_row)
 
-	df_trajectory['grid_id'] = df_trajectory.apply(
-    lambda row: find_grid_id(row['x_final'], row['y_final'], grid_size, map_width, map_height),axis=1)
-	# 'stay'がTrueで、かつ有効なグリッドIDを持つデータのみをフィルタリング
-	stay_points = df_trajectory[(df_trajectory['stay'] == True) & (df_trajectory['grid_id'].notna())]
+def calculate_stay_time(
+    df_trajectory, grid_size, map_width, map_height, excluded_grids=None
+):
+    # diff()で前後の行との差を計算し、最初の行はNaNになるため0で埋める
+    df_trajectory["time_diff"] = df_trajectory["time"].diff().fillna(0)
 
-	# グリッドIDごとに滞在時間('time_diff')を合計
-	stay_time_per_grid = stay_points.groupby('grid_id')['time_diff'].sum()
+    def find_grid_id(x, y, grid_size, map_width_px, map_height_px):
+        """
+        座標(x, y)がどのグリッドIDに属するかを計算する。
+        マップ範囲外の場合は-1を返す。
+        """
+        # print(f"x: {x}, y: {y},grid_size{grid_size}, map_width_px: {map_width_px}, map_height_px: {map_height_px}")
+        if not (0 <= x < map_width_px and 0 <= y < map_height_px):
+            return -1  # マップの範囲外
 
-	# 結果の表示 (滞在時間があったグリッドのみ)
-	# print("--- グリッドごとの滞在時間 ---")
-	# print(stay_time_per_grid[stay_time_per_grid > 0])
-	# print("-" * 20)
+        # 座標がどのグリッドの列・行に位置するかを計算
+        grid_col = int(x // grid_size)
+        grid_row = int(y // grid_size)
 
-	return stay_time_per_grid
+        return (grid_col, grid_row)
+
+    df_trajectory["grid_id"] = df_trajectory.apply(
+        lambda row: find_grid_id(
+            row["x_final"], row["y_final"], grid_size, map_width, map_height
+        ),
+        axis=1,
+    )
+    # 'stay'がTrueで、かつ有効なグリッドIDを持つデータのみをフィルタリング
+    stay_points = df_trajectory[
+        (df_trajectory["stay"] == True) & (df_trajectory["grid_id"].notna())
+    ].copy()
+
+    if excluded_grids:
+        excluded_set = {grid for grid in excluded_grids if grid is not None}
+        if excluded_set:
+            stay_points = stay_points[~stay_points["grid_id"].isin(excluded_set)].copy()
+            if stay_points.empty:
+                return {}
+
+    # グリッドIDごとに滞在時間('time_diff')を合計
+    stay_time_per_grid = stay_points.groupby("grid_id")["time_diff"].sum()
+    if stay_time_per_grid.empty:
+        return {}
+
+    # 結果の表示 (滞在時間があったグリッドのみ)
+    # print("--- グリッドごとの滞在時間 ---")
+    # print(stay_time_per_grid[stay_time_per_grid > 0])
+    # print("-" * 20)
+
+    return stay_time_per_grid.to_dict()

--- a/src/generate_heatmap_data.py
+++ b/src/generate_heatmap_data.py
@@ -33,6 +33,8 @@ def generate_heatmap_data(
     # 全軌跡の値を合算するための配列をゼロで初期化
     total_values = np.zeros((num_grids_y, num_grids_x))
     transformed_list = []
+    initial_position = transform_params.get("initial_position")
+    excluded_grids = {initial_position} if initial_position is not None else None
 
     for file_path in file_paths:
         log.info(
@@ -64,6 +66,7 @@ def generate_heatmap_data(
                 GRID_SIZE_PX,
                 MAP_WIDTH_PX,
                 MAP_HEIGHT_PX,
+                excluded_grids=excluded_grids,
             )
             colorbar_label = "滞在時間 (秒)"
 
@@ -71,6 +74,7 @@ def generate_heatmap_data(
             calculated_values = calculate_stay_count(
                 df_transformed,
                 GRID_SIZE_PX,
+                excluded_grids=excluded_grids,
             )
             colorbar_label = "滞在回数"
 


### PR DESCRIPTION
初期位置をグリッドマップ上で表示させないようにする

↓初期位置を除外した場合と除外しなかった場合のヒートマップ比較(左:除外後,右:除外前)
<img width="921" height="599" alt="スクリーンショット 2026-01-11 15 36 26" src="https://github.com/user-attachments/assets/c902e593-a56f-411b-8de2-6a32ff6c0d84" />
<img width="921" height="599" alt="スクリーンショット 2026-01-11 15 36 37" src="https://github.com/user-attachments/assets/e230b686-d459-47d3-b73c-552027de231c" />
<img width="921" height="599" alt="スクリーンショット 2026-01-11 15 36 49" src="https://github.com/user-attachments/assets/8e0f3dcd-4e24-4e1a-9a88-4047baa47cb6" />
