### PR TITLE
Feature/【add】論文書く用に複数の処理を追加 #90

### DIFF
--- a/src/calculate_stay_count.py
+++ b/src/calculate_stay_count.py
@@ -45,4 +45,10 @@ def calculate_stay_count(df_transformed, GRID_SIZE_PX, excluded_grids=None):
     # グリッドごとの訪問回数をカウント
     stay_counts = grid_visits.groupby(["grid_col", "grid_row"]).size().to_dict()
 
+    # --- デバッグ用出力 ：各グリッドの滞在回数の集計結果【(グリッドID):滞在回数】 ---
+    # print("--- 滞在回数集計結果  ---")
+    # for (col, row), count in stay_counts.items():
+    #     print(f"({col},{row}):{count}")
+    # -----------------------------------------------
+
     return stay_counts

--- a/src/generate_heatmap_data.py
+++ b/src/generate_heatmap_data.py
@@ -90,12 +90,14 @@ def generate_heatmap_data(
             len(file_paths),
             file_path,
         )
-        visualize_trajectory(
-            df_list=transformed_list,
-            background_image=background_image,
-            map_width=MAP_WIDTH_PX,
-            map_height=MAP_HEIGHT_PX,
-            output_dir="output",
-        )
+
+        ## プログラム処理時間の短縮のため、軌跡の可視化はコメントアウトします
+        # visualize_trajectory(
+        #     df_list=transformed_list,
+        #     background_image=background_image,
+        #     map_width=MAP_WIDTH_PX,
+        #     map_height=MAP_HEIGHT_PX,
+        #     output_dir="output",
+        # )
 
     return total_values


### PR DESCRIPTION
論文に書くため以下の処理を追加する．

１つの歩行軌跡における各グリッドIDの滞在回数の集計結果を表示する
必要に応じて，表示する．現状はコメントアウトして非表示にする

【(グリッドID):滞在回数】

 ## 出力例
 
--- 滞在回数集計結果 ---
(8,21):1
(8,24):1
(8,28):1
(9,14):1
(9,16):1
(17,13):1

--- 滞在回数集計結果 ---
(8,14):1
(8,17):1
(15,14):1
(20,9):1
(20,14):1